### PR TITLE
Use git clone instead of submodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "format": "prettier --write --list-different ./src/*.js",
-    "prepare": "git submodule update --init --recursive",
+    "prepare": "git clone https://github.com/rs/SDWebImage.git ios/Vendor/SDWebImage",
     "test": "yarn run format && yarn run test:jest",
     "test:jest": "jest ./src/*.js"
   },


### PR DESCRIPTION
When yarn checks out a package from git, git submodule doesn't work
as there is no .git dir.